### PR TITLE
Fix reduction_ambition to correctly use s2

### DIFF
--- a/SBTi/target_validation.py
+++ b/SBTi/target_validation.py
@@ -168,9 +168,9 @@ class TargetProtocol:
                         target.reduction_ambition
                         * target.coverage_s1
                         * target.base_year_ghg_s1
-                        + s2.reduction_ambition * s2.coverage_s1 * s2.base_year_ghg_s2
+                        + s2.reduction_ambition * s2.coverage_s2 * s2.base_year_ghg_s2
                     )
-                    / (target.base_year_ghg_s1 + s2.base_year_ghg_s1)
+                    / (target.base_year_ghg_s1 + s2.base_year_ghg_s2)
                     / combined_coverage
                 )
                 target.coverage_s1 = combined_coverage


### PR DESCRIPTION
Use s2.coverage_s2 instead of s2.coverage_s1 and s2.base_year_ghg_s2 instead of s2.base_year_ghg_s1
This should cause the combined s1+s2 to correctly account for the s2 part in target.reduction_ambition calculation