### PR TITLE
feature request : time frame 

### DIFF
--- a/SBTi/temperature_score.py
+++ b/SBTi/temperature_score.py
@@ -170,6 +170,7 @@ class TemperatureScore(PortfolioAggregation):
         self,
         time_frames: List[ETimeFrames],
         scopes: List[EScope],
+        year_time_frame: str = 'current',
         fallback_score: float = 3.2,
         model: int = 4,
         scenario: Optional[Scenario] = None,
@@ -184,6 +185,7 @@ class TemperatureScore(PortfolioAggregation):
         self.fallback_score = fallback_score
 
         self.time_frames = time_frames
+        self.year_time_frame = year_time_frame
         self.scopes = scopes
 
         if self.scenario is not None:
@@ -487,7 +489,7 @@ class TemperatureScore(PortfolioAggregation):
         """
         if data is None:
             if data_providers is not None and portfolio is not None:
-                data = utils.get_data(data_providers, portfolio)
+                data = utils.get_data(data_providers, portfolio, self.year_time_frame)
             else:
                 raise ValueError(
                     "You need to pass and either a data set or a list of data providers and companies"

--- a/SBTi/utils.py
+++ b/SBTi/utils.py
@@ -183,7 +183,7 @@ def dataframe_to_portfolio(df_portfolio: pd.DataFrame) -> List[PortfolioCompany]
 
 
 def get_data(
-    data_providers: List[data.DataProvider], portfolio: List[PortfolioCompany]
+    data_providers: List[data.DataProvider], portfolio: List[PortfolioCompany], year_time_frame: str
 ) -> pd.DataFrame:
     """
     Get the required data from the data provider(s), validate the targets and return a 9-box grid for each company.
@@ -205,7 +205,7 @@ def get_data(
     company_data = SBTi().get_sbti_targets(company_data, _make_isin_map(df_portfolio))
 
     # Prepare the data
-    portfolio_data = TargetProtocol().process(target_data, company_data)
+    portfolio_data = TargetProtocol().process(target_data, company_data, year_time_frame)
     portfolio_data = pd.merge(
         left=portfolio_data,
         right=df_portfolio.drop("company_name", axis=1),


### PR DESCRIPTION
I noticed that the time frame parameter of a target is not constant over time : the time frame is set according to the value 'end year of the target' - 'current year'. For example a target which starts in 2020 and ends in 2030 would have a MID time frame if we calculate its temperature score in 2022 (2030-2022=8), but in 2027 it would have a SHORT time frame (2030-2027=3).

I have 2 concerns about this : 
- it does not make sense to have a non constant time frame : we use the annual reduction rate of targets to calculate the temperature scores from the regression models, suggesting that the reduction will be constant over the lifetime of targets.  Let me illustrate : a target which lives from 2020 to 2050 will be mapped to a SHORT regression model in 2046. Therefore the tool will consider that the target is reducing its emissions at a constant rate for a maximum of 5 years, but it does not take into account that the constant reduction started 26 years ago. 
- I am planning to compute everyday the temperature score of a portfolio and track the change over time. Each time the target of a company in my portfolio will change of time frame (between year 2025 and 2026 in my first example), it will be mapped to a different regression model, implying a suddenly non negligible difference of temperature score for no valid reason. I do not want this, and I think most of other asset management teams would agree with me.

I am suggesting either to replace the time frame value (line 249 of SBTI/target_validation.py, see image) by target.end_year - target.base_year (1), or to add a parameter year_time_frame in the calculate() method of the TemperatureScore class : this parameter can only take value ‘current’ (by default) or ‘start’, allowing users to choose which time frame mapping they want to use (‘current’ means the original SBTI time frame method will be used, ‘start’ means it will be the one I am suggesting in (1)) (2). The second option is what I implemented in this pull request. Please note that this branch can be used as the main one since if the parameter year_time_frame is not specified, the time frame calculation method will be the one already existing.