### PR TITLE
Update target_validation.py

### DIFF
--- a/SBTi/target_validation.py
+++ b/SBTi/target_validation.py
@@ -116,7 +116,7 @@ class TargetProtocol:
             s1s2, s3 = target.copy(), None
             if (
                 not pd.isnull(target.base_year_ghg_s1)
-                and not pd.isnull(target.base_year_ghg_s1)
+                and not pd.isnull(target.base_year_ghg_s2)
             ) or target.coverage_s1 == target.coverage_s2:
                 s1s2.scope = EScope.S1S2
                 if (


### PR DESCRIPTION
The 'if' statement line 199 of target_validation.py contains twice the same condition. I guess there is the typing error and one of the target.base_year_ghg_s1 should be turned into target.base_year_ghg_s2. Otherwise, we have the following issue : a S1S2S3 target with no base_year_ghg_s2 and with coverage_s1 != coverage_s2 would be copied as a S1S2 target but without setting coverage_s1=coverage_s2 . This target would have its reduction ambition updated only given coverage_s1, therefore coverage_s2 is not taken into account during the whole proces.