### PR TITLE
S1S2S3 scores ghg requirement

### DIFF
--- a/SBTi/temperature_score.py
+++ b/SBTi/temperature_score.py
@@ -346,7 +346,7 @@ class TemperatureScore(PortfolioAggregation):
         ]
 
         # return default score if ghg scope12 or 3 is empty
-        if row[self.c.COLS.GHG_SCOPE12] is None or row[self.c.COLS.GHG_SCOPE3] is None:
+        if pd.isna(row[self.c.COLS.GHG_SCOPE12]) or pd.isna(row[self.c.COLS.GHG_SCOPE3]):
             return (
                 TemperatureScoreConfig.FALLBACK_SCORE,
                 TemperatureScoreConfig.FALLBACK_SCORE,


### PR DESCRIPTION
This pull request treats the same topic as @dcoulomb issue (edited May 13th). Missing data in the excel file gets the value 'NaN' and testing NaN is None (or even Nan is Nan) always returns False. We should instead use the function pandas.isnull() or pandas.isna() to handle these issues. 