### PR TITLE
add an in-memory provider to avoid file usage

### DIFF
--- a/SBTi/data/inmemory.py
+++ b/SBTi/data/inmemory.py
@@ -1,0 +1,137 @@
+from typing import Type, List
+from pydantic import ValidationError
+import pandas as pd
+from SBTi.data.data_provider import DataProvider
+from SBTi.interfaces import IDataProviderCompany, IDataProviderTarget
+from SBTi.configs import ColumnsConfig
+
+class_definitions = {
+    "fundamental": {
+        "company_name": str,
+        "company_id": str,
+        "isic": str,
+        "country": str,
+        "region": str,
+        "industry_level_1": str,
+        "industry_level_2": str,
+        "industry_level_3": str,
+        "industry_level_4": str,
+        "sector": str,
+        "ghg_s1s2": str,
+        "ghg_s3": str,
+        "company_revenue": str,
+        "company_market_cap": str,
+        "company_enterprise_value": str,
+        "company_total_assets": str,
+        "company_cash_equivalents": str,
+    },
+    "target": {
+        "company_name": str,
+        "company_id": str,
+        "target_type": str,
+        "intensity_metric": str,
+        "scope": str,
+        "coverage_s1": str,
+        "coverage_s2": str,
+        "coverage_s3": str,
+        "reduction_ambition": str,
+        "base_year": str,
+        "end_year": str,
+        "start_year": str,
+        "base_year_ghg_s1": str,
+        "base_year_ghg_s2": str,
+        "base_year_ghg_s3": str,
+        "achieved_reduction": str,
+    },
+}
+
+
+class InMemoryProvider(DataProvider):
+    """
+    Data provider to read in-memory dict.
+
+    :param fundamental: A dictionary with the fundamental data
+    :param targets: A dictionary with the target data
+    """
+
+    def __init__(
+        self,
+        fundamental: class_definitions["fundamental"],
+        targets: class_definitions["target"],
+        config: Type[ColumnsConfig] = ColumnsConfig,
+    ):
+        super().__init__()
+        self.data_fundamental = pd.DataFrame(fundamental)
+        self.data_targets = pd.DataFrame(targets)
+        self.c = config
+
+    def get_targets(self, company_ids: list) -> List[IDataProviderTarget]:
+        """
+        Get all relevant targets for a list of company ids (ISIN). This method should return a list of
+        IDataProviderTarget instances.
+
+        :param company_ids: A list of company IDs (ISINs)
+        :return: A list containing the targets
+        """
+        model_targets = self._target_df_to_model(self.data_targets)
+        model_targets = [
+            target for target in model_targets if target.company_id in company_ids
+        ]
+        return model_targets
+
+    def _target_df_to_model(self, df_targets):
+        """
+        transforms target Dataframe into list of IDataProviderTarget instances
+
+        :param df_targets: pandas Dataframe with targets
+        :return: A list containing the targets
+        """
+        targets = df_targets.to_dict(orient="records")
+        model_targets: List[IDataProviderTarget] = []
+
+        for target in targets:
+            try:
+                model_targets.append(IDataProviderTarget.parse_obj(target))
+            except ValidationError as e:
+                print(
+                    "(one of) the target(s) of company %s is invalid and will be skipped"
+                    % target[self.c.COMPANY_NAME]
+                )
+                continue
+
+        return model_targets
+
+    def get_company_data(self, company_ids: list) -> List[IDataProviderCompany]:
+        """
+        Get all relevant data for a list of company ids (ISIN). This method should return a list of IDataProviderCompany
+        instances.
+
+        :param company_ids: A list of company IDs (ISINs)
+        :return: A list containing the company data
+        """
+        companies = self.data_fundamental.to_dict(orient="records")
+        model_companies: List[IDataProviderCompany] = [
+            IDataProviderCompany.parse_obj(company) for company in companies
+        ]
+        model_companies = [
+            target for target in model_companies if target.company_id in company_ids
+        ]
+        return model_companies
+
+    def get_sbti_targets(self, companies: list) -> list:
+        """
+        For each of the companies, get the status of their target (Target set, Committed or No target) as it's known to
+        the SBTi.
+
+        :param companies: A list of companies. Each company should be a dict with a "company_name" and "company_id"
+                            field.
+        :return: The original list, enriched with a field called "sbti_target_status"
+        """
+        return self.data_fundamental[
+            (
+                self.data_fundamental["company_id"].isin(
+                    [company["company_id"] for company in companies]
+                )
+                & self.data_fundamental["company_id"].notnull()
+            )
+        ].copy()

--- a/test/data/test_inmemory_data.py
+++ b/test/data/test_inmemory_data.py
@@ -1,0 +1,75 @@
+import SBTi.data
+from SBTi import utils
+from SBTi.data.inmemory import InMemoryProvider 
+from SBTi.data.sbti import SBTi  
+
+import os
+import unittest
+import pandas as pd
+
+
+class TestSBTiData(unittest.TestCase):
+    """
+    Test various combinations of ISIN and LEI data.
+    """
+
+    def setUp(self) -> None:
+        self.portfolios = [
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "../",
+                "inputs",
+                "data_test_all_ISIN_LEI.csv"),
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "../",
+                "inputs",
+                "data_test_ISIN_no_LEI.csv"),
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "../",
+                "inputs",
+                "data_test_no_ISIN_all_LEI.csv"),
+        ]
+
+        # read data from excel file
+        data_from_provider = pd.read_excel(os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../",
+            "inputs",
+            "data_test_SBTI_CTA.xlsx",
+        ), sheet_name=None, skiprows=0)
+
+        # use the same excel file to execute the same test suites
+        fundamental = data_from_provider["fundamental_data"]
+        targets = data_from_provider["target_data"]
+
+        self.provider = [InMemoryProvider(fundamental=fundamental, targets=targets)]
+
+    def test_sbti_data(self) -> None:
+        """
+        Test whether data is retrieved as expected from the SBTi wbesite.
+        Also test that ISIN and LEI data are treated correctly in _make_id_map.
+        """
+        for portfolio in self.portfolios:
+            # Read portfolio from csv file into dataframe
+            portfolio = pd.read_csv(portfolio)
+            # Convert dataframe to list of portfolio company objects
+            portfolio = utils.dataframe_to_portfolio(portfolio)
+            df_portfolio = pd.DataFrame.from_records(
+                utils._flatten_user_fields(c) for c in portfolio)
+            company_data = utils.get_company_data(self.provider, df_portfolio["company_id"].tolist())
+            target_data = utils.get_targets(self.provider, df_portfolio["company_id"].tolist())
+            
+            company_data = SBTi().get_sbti_targets(company_data, utils._make_id_map(df_portfolio))
+            # Get SBTi data
+            
+
+            # Check that the data is as expected
+            self.assertEqual(len(company_data), 3)
+
+
+if __name__ == "__main__":
+    test = TestSBTiData()
+    test.setUp()
+    test.test_sbti_data()


### PR DESCRIPTION
# chore(data): add an in-memory provider to avoid file usage

## Introduction
Given the lack of an in-memory provider, this will allow users of the tool to consume from an already in-memory `pd.DataFrame`. This will enable a faster and more flexible approach than reading a binary file.

## Change
Now, users can import an InMemoryProvider and use the data without paths
```python
fundamental = pd.DataFrame()
targets = pd.DataFrame()

provider = InMemoryProvider(fundamental, targets)
```

## Compatibility
This is in addition to the data providers that the library already has.